### PR TITLE
Integrate visual editor plugin with SRPC

### DIFF
--- a/plugins/visual-editor/src/visual-editor-plugin.tsx
+++ b/plugins/visual-editor/src/visual-editor-plugin.tsx
@@ -5,7 +5,14 @@ import {
   VisualEditorSidebar,
   useVisualEditingSelector,
 } from '@stagewise/toolbar';
-import { Fragment, useEffect } from '@stagewise/toolbar/plugin-ui';
+import {
+  Fragment,
+  useEffect,
+  useState,
+  useCallback,
+} from '@stagewise/toolbar/plugin-ui';
+import { useSRPCBridge, useVSCode } from '@stagewise/toolbar';
+import type { StyleChange } from '@stagewise/toolbar';
 import { VisualEditorIcon } from './visual-editor-icon';
 
 function VisualEditorRoot() {
@@ -15,8 +22,65 @@ function VisualEditorRoot() {
     handleElementSelected,
     clearSelection,
   } = useVisualEditingSelector();
+  const { bridge } = useSRPCBridge();
+  const { selectedSession } = useVSCode();
+  const [sourceInfo, setSourceInfo] = useState<
+    | import('@stagewise/extension-toolbar-srpc-contract').ElementSourceInfoResponse['result']
+    | null
+  >(null);
 
   useEffect(() => clearSelection, [clearSelection]);
+
+  useEffect(() => {
+    if (!bridge || !selectedMetadata) return;
+    const selector = selectedMetadata.visualEditingInfo?.cssSelector;
+    if (!selector) return;
+
+    bridge.call
+      .getElementSourceInfo(
+        {
+          elementSelector: selector,
+          componentName: selectedMetadata.frameworkInfo?.componentName,
+          frameworkType:
+            selectedMetadata.frameworkInfo?.framework || 'unknown',
+          ...(selectedSession && { sessionId: selectedSession.sessionId }),
+        },
+        { onUpdate: () => {} },
+      )
+      .then((res) => {
+        setSourceInfo(res.result);
+      })
+      .catch(() => setSourceInfo(null));
+  }, [bridge, selectedMetadata, selectedSession]);
+
+  const handleApplyChanges = useCallback(
+    async (changes: StyleChange[]) => {
+      if (!bridge || !selectedMetadata) return;
+      const selector = selectedMetadata.visualEditingInfo?.cssSelector;
+      if (!selector) return;
+      const styles: Record<string, string> = {};
+      changes.forEach((c) => {
+        styles[c.property] = c.value;
+      });
+
+      try {
+        await bridge.call.updateElementStyles(
+          {
+            elementSelector: selector,
+            styles,
+            sourceFile: sourceInfo?.sourceFile,
+            componentName: sourceInfo?.componentInfo?.name,
+            updateType: sourceInfo?.styleType,
+            ...(selectedSession && { sessionId: selectedSession.sessionId }),
+          },
+          { onUpdate: () => {} },
+        );
+      } catch (err) {
+        console.error('Failed to update element styles', err);
+      }
+    },
+    [bridge, selectedMetadata, selectedSession, sourceInfo],
+  );
 
   return (
     <Fragment>
@@ -28,6 +92,7 @@ function VisualEditorRoot() {
         selectedElement={selectedElement}
         selectedMetadata={selectedMetadata}
         onClose={clearSelection}
+        onApplyChanges={handleApplyChanges}
       />
     </Fragment>
   );


### PR DESCRIPTION
## Summary
- hook the Visual Editor plugin into SRPC so style changes sync back to the editor

## Testing
- `pnpm check` *(fails: request to npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6849e18f44b4832d8ca915784e6c5f04